### PR TITLE
remove duplicate log message being logged under “method”.

### DIFF
--- a/DDAntennaLogger/DDAntennaLogger.m
+++ b/DDAntennaLogger/DDAntennaLogger.m
@@ -30,7 +30,6 @@
 {
     NSDictionary *logPayload = @{
                                  @"file": logMessage.fileName,
-                                 @"method": logMessage->_message,
                                  @"timestamp": logMessage->_timestamp,
                                  @"log-level": @(logMessage->_level),
                                  };


### PR DESCRIPTION
As it is, I have the same log message being logged twice; I tried to make it log the actual original method but we can't access the original method from where we are so I removed it entirely. 